### PR TITLE
Added limit to args when creating event from string

### DIFF
--- a/lib/ga_events/event.rb
+++ b/lib/ga_events/event.rb
@@ -11,7 +11,7 @@ module GaEvents
     end
 
     def self.from_string(str)
-      new(*str.split('|'))
+      new(*str.split('|').take(4))
     end
   end
 end


### PR DESCRIPTION
In our use of the Gem, we were getting a ArgumentError due to `event.from_string` somehow splatting too many arguments for `event.initialize`