### PR TITLE
Encode category, action and label

### DIFF
--- a/app/assets/javascripts/ga_events.js.coffee
+++ b/app/assets/javascripts/ga_events.js.coffee
@@ -14,7 +14,8 @@ class GaEvents.Event
   # Decompose a dom-string (ruby side) into an event object.
   @from_string: (string) ->
     $.map string.split("$"), (part) =>
-      [category, action, label, value] = part.split "|"
+      [category, action, label, value] =
+        $.map part.split("|"), (val) -> decodeURIComponent(val)
       new @(category, action, label, value)
 
   # Events should not be send to an adapter unless the DOM has finished loading.

--- a/lib/ga_events.rb
+++ b/lib/ga_events.rb
@@ -1,1 +1,2 @@
+require 'uri'
 %w(middleware engine event list version).each { |f| require "ga_events/#{f}" }

--- a/lib/ga_events/event.rb
+++ b/lib/ga_events/event.rb
@@ -7,11 +7,11 @@ module GaEvents
     end
 
     def to_s
-      [category, action, label, value].join('|')
+      ([category, action, label].map { |e| URI.encode(e) } + [value]).join('|')
     end
 
     def self.from_string(str)
-      new(*str.split('|'))
+      new(*str.split('|').map { |e| URI.decode(e) })
     end
   end
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -55,5 +55,23 @@ describe GaEvents::Middleware do
         end
       end
     end
+
+    context 'encodes pipes in event correctly' do
+      let(:app) do
+        proc do |_|
+          GaEvents::Event.new('category', 'action', 'we|love|pipes')
+          [200, { 'Content-Type' => 'text/html' }, response_body]
+        end
+      end
+      let(:response_body) { 'something awesome!</body>' }
+      let(:response) { request.get('/') }
+
+      it 'does not raise an exception' do
+        expect(response.body).to eq(
+          'something awesome!' \
+          "<div data-ga-events='category|action|we%7Clove%7Cpipes|1'></div></body>"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
As mentioned by @der-flo in GH-20 event data does not get properly encoded. This is a small fix to do just this.
